### PR TITLE
docs(adr): add ADR 0003 — Day 1 scope boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,15 @@ npm run lint     # ESLint checks
 - `tsx watch` for dev, `tsc` for production builds
 - Provider plugins use relative imports back to `src/server/` (not `@openclaw/installer/*`)
 
+## Scope Guard
+
+The installer handles **Day 1 deployment only**. Features that can be performed
+after deployment using the OpenClaw CLI (`openclaw <command>`) or the OpenClaw UI
+must not be added to the installer. Before proposing a feature, ask: "Is this
+needed on first launch?" If not, it belongs upstream. See
+[ADR 0003](adr/0003-day-1-scope-boundary.md) for the full rationale and decision
+framework.
+
 ## Build Configuration
 
 - `tsconfig.server.json` -- compiles `src/server/` to `dist/`

--- a/adr/0003-day-1-scope-boundary.md
+++ b/adr/0003-day-1-scope-boundary.md
@@ -1,0 +1,95 @@
+# ADR 0003: Day 1 Scope Boundary
+
+## Status
+
+Proposed
+
+## Context
+
+The installer deploys OpenClaw to local containers, Kubernetes, and OpenShift. As the UI matures, there is a natural pull to add post-deployment management features — configuration editing, updates, plugin management, health dashboards, log viewers — because the installer already has a web interface and access to the running instance.
+
+Upstream OpenClaw ships a comprehensive CLI (`openclaw`) that already covers these operations:
+
+| Category | CLI commands |
+| --- | --- |
+| Configuration | `config get\|set\|unset\|validate`, `configure` |
+| Updates | `update stable\|beta\|dev` |
+| Plugin management | `plugins list\|install\|enable\|disable\|doctor` |
+| Health & diagnostics | `health`, `doctor`, `status --deep` |
+| Logs | `logs --follow` |
+| Backup & restore | `backup create\|verify` |
+| Secret management | `secrets audit\|configure\|apply\|reload` |
+| Security audit | `security` |
+| Channel management | `channels add\|remove\|login\|logout` |
+| Scheduling | `cron add\|edit\|rm\|enable\|disable` |
+| Hook & webhook management | `hooks`, `webhooks` |
+
+Duplicating any of these capabilities in the installer creates the same problems that ADR 0001 identified for hardcoded deploy targets: unbounded scope, maintenance burden, and divergence from upstream behavior. It also fragments the user's mental model — they must learn which operations live in the installer UI versus the CLI.
+
+## Decision
+
+The installer's scope is limited to **Day 1 operations**: everything required to go from zero to a running OpenClaw instance. Anything that can be performed after deployment using the OpenClaw CLI or UI is out of scope for the installer.
+
+### What is in scope (Day 1)
+
+- Collecting deployment configuration (target platform, model providers, agent workspace)
+- Secret injection at deploy time (API keys, SecretRefs)
+- Provisioning infrastructure (containers, K8s resources, volumes)
+- Writing initial `openclaw.json` and agent workspace files
+- Instance lifecycle tied to deployment: start, stop, redeploy, delete
+- One-way workspace sync from host into the running instance
+
+### What is out of scope (Day 2)
+
+Any operation that modifies a running instance's behavior or state after initial deployment, including but not limited to:
+
+- **Configuration changes** — use `openclaw config` or `openclaw configure`
+- **Version updates** — use `openclaw update`
+- **Plugin management** — use `openclaw plugins`
+- **Health monitoring and diagnostics** — use `openclaw health`, `openclaw doctor`, `openclaw status`
+- **Log viewing** — use `openclaw logs`
+- **Backup and restore** — use `openclaw backup`
+- **Channel, hook, cron, and secret management** — use the respective CLI commands
+
+### Decision framework
+
+Before adding a feature to the installer, apply this test:
+
+1. **Is this feature needed on first launch?** If no, it is out of scope.
+2. **Can `openclaw <command>` already do this?** If yes, it is out of scope.
+3. **Does this modify a running instance's behavior?** If yes, it is out of scope.
+
+If a feature fails any of these checks, the correct response is to document how to use the CLI for that operation (e.g., in `docs/`) rather than to build it into the installer.
+
+### Exceptions
+
+The installer may provide **pointers** to Day 2 operations without implementing them:
+
+- A post-deploy summary page that lists useful CLI commands
+- Links to upstream documentation for common next steps
+- `docs/` guides that show how to use the CLI with installer-provisioned instances (as `docs/openclaw-cli-local.md` already does)
+
+## Consequences
+
+### Positive
+
+- Keeps the installer focused and maintainable.
+- Avoids behavioral divergence between the installer UI and the upstream CLI.
+- Reduces the risk of the installer becoming a parallel management plane that must track every upstream CLI change.
+- Gives contributors a clear, testable criterion for evaluating feature requests.
+
+### Negative
+
+- Some users may expect a single UI for both deployment and management. They will need to learn the CLI for Day 2 operations.
+- Feature requests that cross the boundary will need to be redirected upstream, which requires active triage.
+
+### Risks
+
+- The boundary may occasionally be ambiguous (e.g., "redeploy with new config" straddles Day 1 and Day 2). When this happens, prefer the narrower interpretation and discuss in the issue before implementing.
+
+## References
+
+- [Issue #59: Don't recreate the OpenClaw CLI](https://github.com/sallyom/openclaw-installer/issues/59)
+- [ADR 0001: Deployer Plugin System](./0001-deployer-plugin-system.md) — precedent for avoiding unbounded scope
+- [ADR 0002: Agent Security Surface](./0002-agent-security-surface.md) — precedent for preferring upstream OpenClaw features
+- [docs/openclaw-cli-local.md](../docs/openclaw-cli-local.md) — existing example of pointing users to the CLI

--- a/adr/README.md
+++ b/adr/README.md
@@ -8,3 +8,4 @@ This directory contains architecture decision records for `openclaw-installer`.
 | --- | --- | --- | --- |
 | [0001](./0001-deployer-plugin-system.md) | Accepted | Deployer Plugin System | Adds the core/provider deployer plugin architecture and runtime plugin loading model. |
 | [0002](./0002-agent-security-surface.md) | Proposed | Agent Security Surface | Establishes `Agent Security` as the installer UX surface for SecretRefs now and future hardening later. |
+| [0003](./0003-day-1-scope-boundary.md) | Proposed | Day 1 Scope Boundary | Limits the installer to first-launch operations; Day 2 management belongs to the OpenClaw CLI. |


### PR DESCRIPTION
## Summary

- Adds **ADR 0003** establishing that the installer handles only Day 1 (first-launch) operations
- Day 2 operations (config changes, updates, plugin management, health monitoring, etc.) belong to the OpenClaw CLI and UI
- Includes a 3-question decision framework for evaluating feature requests against this boundary
- Adds a **Scope Guard** section to AGENTS.md so contributors and AI agents apply the boundary

## Context

Issue #59 proposes that the installer should not recreate features already available in the OpenClaw CLI. This ADR formalizes that principle with:

- A concrete table of CLI commands that are out of scope
- Clear definitions of what constitutes Day 1 vs Day 2
- A decision framework: "Is this needed on first launch? Can openclaw <command> already do it? Does it modify a running instance?"
- An exception for pointers (post-deploy summaries, docs, CLI guides)

## Files changed

| File | Change |
| --- | --- |
| adr/0003-day-1-scope-boundary.md | New ADR |
| adr/README.md | Updated index with ADR 0003 |
| AGENTS.md | Added Scope Guard section |

Refs #59
